### PR TITLE
test(sim): 6 Integrationstests für Testpyramiden-Lücken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 
 ### Added
 
+- `sim/sim_test.go`: 6 neue Integrationstests (fehlende Testpyramiden-Ebenen):
+  - `TestNoDuplicateIDs` — Partition-Sync via `DebugIntegrity=true`
+  - `TestNoWaterIndividuals` — räumliche Konsistenz: kein Individuum auf Wasser
+  - `TestSnapshotPopMatchesPartitions` — Snapshot-Population stimmt mit Partitionssumme überein
+  - `TestBoundaryCrossing` — Individuen überschreiten Partitionsgrenzen
+  - `TestFoodNeverNegative` — Tile-Nahrung wird durch Fressen nie negativ
+  - `TestEnergyRegrown_Nonnegative` — `EnergyRegrown` ist pro Tick nicht negativ
+
 - `README.md`: vollständig überarbeitet — Build-Anleitung, Steuerung, Ansichtsübersicht, aktueller Meilenstein-Status
 - `CONTRIBUTING.md`: für externe Beitragende überarbeitet — Schnelleinstieg, Merge-Kriterien, Anleitungen für neue Gene und ADRs
 - `.github/ISSUE_TEMPLATE/bug_report.md` + `feature_request.md`: strukturierte Issue-Vorlagen

--- a/sim/sim_test.go
+++ b/sim/sim_test.go
@@ -152,6 +152,144 @@ func TestMutateBounds(t *testing.T) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// Integrationstests
+// ---------------------------------------------------------------------------
+
+// TestNoDuplicateIDs prüft Partition-Sync: keine doppelten Individual-IDs über Partitionen.
+// DebugIntegrity=true lässt checkIntegrity() paniken → Panic bricht Test ab.
+func TestNoDuplicateIDs(t *testing.T) {
+	cfg := testConfig()
+	cfg.DebugIntegrity = true
+	rng := newTestRng(42)
+	s, _, err := New(cfg, rng, nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for range 100 {
+		s.Step()
+	}
+}
+
+// TestNoWaterIndividuals prüft räumliche Konsistenz: kein Individuum auf Wasser-Tile.
+func TestNoWaterIndividuals(t *testing.T) {
+	cfg := testConfig()
+	rng := newTestRng(42)
+	s, _, err := New(cfg, rng, nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for tick := range 50 {
+		s.Step()
+		for _, ind := range s.allIndividuals() {
+			tile := s.grid.At(ind.Pos.X, ind.Pos.Y)
+			if tile == nil || !tile.IsWalkable() {
+				t.Errorf("tick %d: Individuum ID=%d auf nicht-begehbarer Tile (%d,%d)",
+					tick, ind.ID, ind.Pos.X, ind.Pos.Y)
+			}
+		}
+	}
+}
+
+// TestSnapshotPopMatchesPartitions prüft dass snap.Stats.Population mit der
+// tatsächlichen Summe der Partitions-Individuen übereinstimmt.
+func TestSnapshotPopMatchesPartitions(t *testing.T) {
+	cfg := testConfig()
+	rng := newTestRng(42)
+	s, exp, err := New(cfg, rng, nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for tick := range 50 {
+		s.Step()
+		snap := exp.Load()
+		if snap == nil {
+			t.Fatalf("tick %d: snapshot is nil", tick)
+		}
+		actual := s.totalPopulation()
+		if snap.Stats.Population != actual {
+			t.Errorf("tick %d: snap.Population=%d != totalPopulation=%d",
+				tick, snap.Stats.Population, actual)
+		}
+		if len(snap.Individuals) != actual {
+			t.Errorf("tick %d: len(snap.Individuals)=%d != totalPopulation=%d",
+				tick, len(snap.Individuals), actual)
+		}
+	}
+}
+
+// TestBoundaryCrossing prüft dass Individuen nach mehreren Ticks tatsächlich
+// Partitionsgrenzen überschreiten — beide Partitionen haben Individuen.
+func TestBoundaryCrossing(t *testing.T) {
+	cfg := testConfig()
+	cfg.NumPartitions = 2
+	rng := newTestRng(99)
+	s, _, err := New(cfg, rng, nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for range 200 {
+		s.Step()
+	}
+	for i, p := range s.partitions {
+		if p.LiveCount() == 0 {
+			t.Errorf("Partition %d hat nach 200 Ticks 0 Individuen — Boundary-Crossing defekt", i)
+		}
+	}
+}
+
+// TestFoodNeverNegative prüft dass tile.Food durch Fressen niemals negativ wird.
+func TestFoodNeverNegative(t *testing.T) {
+	cfg := testConfig()
+	rng := newTestRng(42)
+	s, _, err := New(cfg, rng, nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for tick := range 100 {
+		s.Step()
+		for i, tile := range s.grid.Tiles {
+			if tile.Food < -1e-4 {
+				t.Errorf("tick %d: Tile[%d] hat negative Nahrung: %f", tick, i, tile.Food)
+			}
+		}
+	}
+}
+
+// TestEnergyRegrown_Nonnegative prüft dass EnergyRegrown pro Tick niemals negativ ist.
+func TestEnergyRegrown_Nonnegative(t *testing.T) {
+	type tickStats struct{ regrown float32 }
+	var recorded []tickStats
+	obs := &tickRecorder{fn: func(_ uint64, st TickStats) {
+		recorded = append(recorded, tickStats{regrown: st.EnergyRegrown})
+	}}
+	cfg := testConfig()
+	rng := newTestRng(42)
+	s, _, err := New(cfg, rng, obs)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	for range 50 {
+		s.Step()
+	}
+	for i, ts := range recorded {
+		if ts.regrown < 0 {
+			t.Errorf("tick %d: EnergyRegrown=%f ist negativ", i, ts.regrown)
+		}
+	}
+}
+
+// tickRecorder ist ein TickObserver für Tests.
+type tickRecorder struct {
+	fn func(tick uint64, stats TickStats)
+}
+
+func (r *tickRecorder) OnTick(tick uint64, stats TickStats) { r.fn(tick, stats) }
+
+// ---------------------------------------------------------------------------
+// Populationsgrenzen
+// ---------------------------------------------------------------------------
+
 // TestPopulationCap prüft dass die Population MaxPopulation nie überschreitet.
 func TestPopulationCap(t *testing.T) {
 	cfg := testConfig()


### PR DESCRIPTION
## Was ändert sich?

Schließt die identifizierten Lücken in der Integrations-Ebene der Testpyramide.

## Neue Tests

| Test | Invariante |
|---|---|
| `TestNoDuplicateIDs` | Partition-Sync: `DebugIntegrity=true` — Panic bei doppelter ID bricht Test ab |
| `TestNoWaterIndividuals` | Räumliche Konsistenz: kein Individuum steht nach einem Tick auf Wasser |
| `TestSnapshotPopMatchesPartitions` | `snap.Stats.Population` und `len(snap.Individuals)` stimmen mit `totalPopulation()` überein |
| `TestBoundaryCrossing` | Beide Partitionen haben nach 200 Ticks Individuen — Boundary-Crossing funktioniert |
| `TestFoodNeverNegative` | `tile.Food` wird durch Fressen nie negativ |
| `TestEnergyRegrown_Nonnegative` | `TickStats.EnergyRegrown` ist pro Tick ≥ 0 (via TickObserver) |

## Checkliste

- [x] `make ci` grün
- [x] `go test -race ./sim/...` grün
- [x] `CHANGELOG.md` aktualisiert
- [x] Kein Produktionscode geändert