### PR TITLE
chore: config/testdata/ ins .gitignore aufnehmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 *.test
 *.out
 vendor/
+
+# Test-Artefakte
+config/testdata/


### PR DESCRIPTION
Generierte Test-Artefakte aus `config/testdata/` werden nicht mehr versioniert.