### PR TITLE
ci: complete Node 24 action migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Zusammenfassung
- migriert verbleibende JavaScript-Actions auf Node-24-kompatible Major-Versionen
- nutzt bei Release-Please-Repositories die aktuelle GitHub-App-`client-id`
- entfernt damit Node-20- und `app-id`-Deprecation-Warnungen

## Validierung
- Workflow-YAML mit PyYAML geparst
- `git diff --check`
- offizielle `action.yml`-Runtimes geprüft
- fachliches Read-only-Review: Go