### PR TITLE
chore(config): evaluate predator balance parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 - `sim/predator/predator.go`: Kill-Wahrscheinlichkeit = `GeneAggression` eingeführt — Räuber töten Beute nicht mehr deterministisch jeden Tick; bei Jagdmisserfolg oder keiner Beute in Sichtweite wird Random Walk ausgeführt (behebt auch Stagnation wenn nur Räuber in der Nähe). Lotka-Volterra-Gleichgewicht: H*≈133, P*≈8
 - `config/config.go`: `Predator.EnergyPerKill` 40→8, `Predator.ReproThreshold` 120→360 — Räuber-Population wächst deutlich langsamer; verhindert Overshoot und anschließenden Zusammenbruch nach 300–400 Ticks
 - `sim/sim.go`: `applyPhase2` — Räuber greifen keine anderen Räuber (inkl. sich selbst) an; `EntityType`-Check verhindert Selbst- und Räuber-auf-Räuber-Angriffe die zuvor zur sofortigen Dezimierung der Räuber-Population führten
+- `evolution.toml`: experimentelle Räuber-Startzahl und Reproduktionsparameter für einen reproduzierbaren Balancing-Vergleich erfasst
 
 ### Added
 

--- a/config/evolution_toml_test.go
+++ b/config/evolution_toml_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestEvolutionTOMLValid(t *testing.T) {
+	cfg := DefaultConfig()
+	if _, err := toml.DecodeFile("../evolution.toml", &cfg); err != nil {
+		t.Fatalf("DecodeFile(evolution.toml) error: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("evolution.toml is invalid: %v", err)
+	}
+}

--- a/evolution.toml
+++ b/evolution.toml
@@ -27,11 +27,11 @@ recover_threshold   = 0.50
 
 # --- Räuber ---
 [predator]
-initial_predators = 18      # Puffer gegen stochastische Extinction ohne Überjagd
-energy_per_kill   = 7.0     # moderat höher als 5.0 → überlebt Hungerperioden
-repro_threshold   = 340.0   # nah am Original → langsames Wachstum, kein Populationsboom
-repro_reserve     = 60.0    # Startenergie Räuber-Kind
-max_sight         = 20      # 2× Herbivore-Sichtweite
+initial_predators = 1       # näher an P*≈8 → geringerer Überschuss, kleinere Schwingung
+energy_per_kill   = 10.0    # etwas mehr Buffer bei wenig Beute
+repro_threshold   = 620.0   # langsame Reproduktion → kleinere Spitzenpopulation
+repro_reserve     = 80.0    # Nachkommen starten mit mehr Energie → bessere Überlebenschaft
+max_sight         = 21      # 2× Herbivore-Sichtweite
 
 # --- Gene ---
 [[gene_definitions]]


### PR DESCRIPTION
## Status
Draft — **nicht mergen**, bis eine bessere Parameterkombination messbar nachgewiesen ist.

## Ursprüngliche lokale Arbeit
- `InitialPredators`: 18 → 1
- `EnergyPerKill`: 7 → 10
- `ReproThreshold`: 340 → 620
- `ReproReserve`: 60 → 80
- `MaxSight`: 20 → 21
- struktureller Lade-/Validierungstest für `evolution.toml`

## Messergebnis
Vergleich über 2.000 Ticks und fünf Seeds:

- bisherige Werte: Herbivoren-Maxima 473–938; Räuber bis Tick 2000 in 5/5 Läufen ausgestorben
- vorgeschlagene Werte: Herbivoren-Maxima 1.244–1.388; Räuber in 4/5 Läufen ausgestorben
- vier weitere Kandidaten: Räuber in allen 20 Läufen ausgestorben; teils höhere Peaks oder Gesamtkollaps

Die vorgeschlagene Konfiguration erreicht das Ziel kleinerer Populationsspitzen nicht und bleibt daher bewusst Draft.

## Validierung
- `make test-sim` grün
- `evolution.toml` wird in einem neuen Test geladen und mit `Config.Validate()` geprüft
- GUI-Start lokal nicht geprüft: System-Linker findet `libXxf86vm` nicht; CI bleibt maßgeblich
- fachliches Read-only-Review: No-Go für Merge ohne Messbeleg